### PR TITLE
add support for custom axios instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import axios from "axios";
 import Queue from "better-queue";
 import MemoryStore from "better-queue-memory";
 import Builder from "./builder";
+const axiosInstance = axios.create();
 
 class Apicalypse extends Builder {
   constructor(opts) {
@@ -43,7 +44,8 @@ class Apicalypse extends Builder {
   }
 
   async request(url) {
-    const response = await axios.create()(this.constructOptions(url));
+    const axiosInstance = this.config.axiosInstance || axiosInstance;
+    const response = await axiosInstance(this.constructOptions(url));
     return response;
   }
 


### PR DESCRIPTION
- Added support for providing custom axios instance from config.

This is required if we want to add support for `axios-retry`, which requires axios instance to attach to, This PR will allow writing code like below:

```javascript
const axios = require('axios').default
const axiosRetry = require('axios-retry').default
const apicalypse = require('apicalypse').default

const axiosInstance = axios.create()
axiosRetry(axiosInstance, {
  retries: 3,
  retryDelay: axiosRetry.exponentialDelay,
  retryCondition: error => {
    return axiosRetry.isNetworkOrIdempotentRequestError(error) ||
      error.response && error.response.status === 429
  }
});
const requestOptions = {
  queryMethod: 'body',
  method: 'post',
  baseURL: 'https://api.igdb.com/v4',
  responseType: 'json',
  timeout: 10000,
  axiosInstance,
}
const apicalypsePromise = apicalypse(requestOptions)
```